### PR TITLE
added reset method

### DIFF
--- a/src/Provable.php
+++ b/src/Provable.php
@@ -5,44 +5,44 @@ namespace Gamebetr\Provable;
 class Provable implements ProvableInterface
 {
     /**
-     * client seed
-     * @var string $clientSeed
+     * client seed.
+     * @var string
      */
     private $clientSeed;
 
     /**
-     * server seed
-     * @var string $serverSeed
+     * server seed.
+     * @var string
      */
     private $serverSeed;
 
     /**
-     * min number
-     * @var int $min
+     * min number.
+     * @var int
      */
     private $min;
 
     /**
-     * max number
-     * @var int $max
+     * max number.
+     * @var int
      */
     private $max;
 
     /**
-     * type
-     * @var string $type
+     * type.
+     * @var string
      */
     private $type;
 
-  /**
-   * If the random seed has already been set for mt_rand().
-   *
-   * @var bool
-   */
-  protected $random_seed_set = FALSE;
+    /**
+     * If the random seed has already been set for mt_rand().
+     *
+     * @var bool
+     */
+    protected $random_seed_set = false;
 
     /**
-     * class constructor
+     * class constructor.
      * @param string $clientSeed
      * @param string $serverSeed
      * @param int $min
@@ -59,7 +59,7 @@ class Provable implements ProvableInterface
     }
 
     /**
-     * static constructor
+     * static constructor.
      * @param string $clientSeed
      * @param string $serverSeed
      * @param int $min
@@ -73,18 +73,19 @@ class Provable implements ProvableInterface
     }
 
     /**
-     * client seed setter
+     * client seed setter.
      * @param string $clientSeed
      * @return \Gamebetr\Provable\ProvableInterface
      */
     public function setClientSeed(string $clientSeed = null): ProvableInterface
     {
         $this->clientSeed = $clientSeed ?? $this->generateRandomSeed();
+
         return $this;
     }
 
     /**
-     * client seed getter
+     * client seed getter.
      * @return string
      */
     public function getClientSeed():  string
@@ -93,18 +94,19 @@ class Provable implements ProvableInterface
     }
 
     /**
-     * server seed setter
+     * server seed setter.
      * @param string $serverSeed
      * @return \Gamebetr\Provable\ProvableInterface
      */
     public function setServerSeed(string $serverSeed = null): ProvableInterface
     {
         $this->serverSeed = $serverSeed ?? $this->generateRandomSeed();
+
         return $this;
     }
 
     /**
-     * server seed getter
+     * server seed getter.
      * @return string
      */
     public function getServerSeed(): string
@@ -113,7 +115,7 @@ class Provable implements ProvableInterface
     }
 
     /**
-     * hashed server seed getter
+     * hashed server seed getter.
      * @return string
      */
     public function getHashedServerSeed(): string
@@ -122,18 +124,19 @@ class Provable implements ProvableInterface
     }
 
     /**
-     * min setter
+     * min setter.
      * @param int $min
      * @return \Gamebetr\Provable\ProvableInterface
      */
     public function setMin(int $min): ProvableInterface
     {
         $this->min = $min;
+
         return $this;
     }
 
     /**
-     * min getter
+     * min getter.
      * @return int
      */
     public function getMin(): int
@@ -142,18 +145,19 @@ class Provable implements ProvableInterface
     }
 
     /**
-     * max setter
+     * max setter.
      * @param int $max
      * @return \Gamebetr\Provable\ProvableInterface
      */
     public function setMax(int $max): ProvableInterface
     {
         $this->max = $max;
+
         return $this;
     }
 
     /**
-     * max getter
+     * max getter.
      * @return int
      */
     public function getMax(): int
@@ -162,21 +166,22 @@ class Provable implements ProvableInterface
     }
 
     /**
-     * type setter
+     * type setter.
      * @param string $type - number|shuffle
      * @return \Gamebetr\Provable\ProvableInterface
      */
     public function setType(string $type): ProvableInterface
     {
-        if (!in_array($type, ['number', 'shuffle'])) {
+        if (! in_array($type, ['number', 'shuffle'])) {
             throw new \Exception("Invalid type $type", 400);
         }
         $this->type = $type;
+
         return $this;
     }
 
     /**
-     * type getter
+     * type getter.
      * @return string
      */
     public function getType(): string
@@ -185,7 +190,7 @@ class Provable implements ProvableInterface
     }
 
     /**
-     * returns the results
+     * returns the results.
      * @return int|array
      */
     public function results()
@@ -199,10 +204,10 @@ class Provable implements ProvableInterface
     }
 
     /**
-     * returns a random number within a range
+     * returns a random number within a range.
      * @param int $minimumNumber
      * @param int $maximumNumber
-     * @return Int
+     * @return int
      */
     public function number(int $minimumNumber = null, int $maximumNumber = null) :int
     {
@@ -212,8 +217,8 @@ class Provable implements ProvableInterface
         if ($maximumNumber !== null) {
             $this->setMax($maximumNumber);
         }
-        if (!$this->random_seed_set) {
-            $this->random_seed_set = TRUE;
+        if (! $this->random_seed_set) {
+            $this->random_seed_set = true;
             mt_srand($this->generateSeedInteger());
         }
 
@@ -222,7 +227,7 @@ class Provable implements ProvableInterface
 
     /**
      * returns a random shuffle of numbers within a range
-     * uses fisher yates shuffle (https://en.wikipedia.org/wiki/Fisher–Yates_shuffle)
+     * uses fisher yates shuffle (https://en.wikipedia.org/wiki/Fisher–Yates_shuffle).
      * @param int $minimumNumber
      * @param int $maximumNumber
      * @return array
@@ -243,11 +248,12 @@ class Provable implements ProvableInterface
             $range[$i] = $range[$j];
             $range[$j] = $tmp;
         }
+
         return $range;
     }
 
     /**
-     * generate a seed integer from server seed and client seed
+     * generate a seed integer from server seed and client seed.
      * @return int
      */
     private function generateSeedInteger(): int
@@ -256,12 +262,23 @@ class Provable implements ProvableInterface
     }
 
     /**
-     * generate a random seed
-     * @var int $seedLength
+     * generate a random seed.
+     * @var int
      * @return string
      */
     private function generateRandomSeed(): string
     {
         return bin2hex(openssl_random_pseudo_bytes(32));
+    }
+
+    /**
+     * Reset the class to start the results over.
+     * @return self
+     */
+    public function reset(): ProvableInterface
+    {
+        $this->random_seed_set = false;
+
+        return $this;
     }
 }

--- a/src/ProvableInterface.php
+++ b/src/ProvableInterface.php
@@ -1,13 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Gamebetr\Provable;
 
 /**
- * Interface ProvableInterface
+ * Interface ProvableInterface.
  */
-interface ProvableInterface {
-
+interface ProvableInterface
+{
     /**
      * Get the client seed.
      *
@@ -66,7 +67,7 @@ interface ProvableInterface {
      * @return int
      *   The randomly generated number.
      */
-    public function number(int $minimumNumber = NULL, int $maximumNumber = NULL): int;
+    public function number(int $minimumNumber = null, int $maximumNumber = null): int;
 
     /**
      * Returns the results for the provable.
@@ -84,7 +85,7 @@ interface ProvableInterface {
      * @return \Gamebetr\Provable\ProvableInterface
      *   An instance of this object.
      */
-    public function setClientSeed(string $clientSeed = NULL): ProvableInterface;
+    public function setClientSeed(string $clientSeed = null): self;
 
     /**
      * Set the maximum allowed random number value.
@@ -95,7 +96,7 @@ interface ProvableInterface {
      * @return \Gamebetr\Provable\ProvableInterface
      *   An instance of this object.
      */
-    public function setMax(int $max): ProvableInterface;
+    public function setMax(int $max): self;
 
     /**
      * Set the minimum allowed random number.
@@ -106,7 +107,7 @@ interface ProvableInterface {
      * @return \Gamebetr\Provable\ProvableInterface
      *   An instance of this object.
      */
-    public function setMin(int $min): ProvableInterface;
+    public function setMin(int $min): self;
 
     /**
      * Set the server seed.
@@ -117,7 +118,7 @@ interface ProvableInterface {
      * @return \Gamebetr\Provable\ProvableInterface
      *   An instance of this object.
      */
-    public function setServerSeed(string $serverSeed = NULL): ProvableInterface;
+    public function setServerSeed(string $serverSeed = null): self;
 
     /**
      * Set the provable type.
@@ -128,7 +129,7 @@ interface ProvableInterface {
      * @return \Gamebetr\Provable\ProvableInterface
      *   An instance of this object.
      */
-    public function setType(string $type): ProvableInterface;
+    public function setType(string $type): self;
 
     /**
      * Get a random shuffle of numbers within a range.
@@ -143,6 +144,13 @@ interface ProvableInterface {
      * @return int[]|array
      *   Returns a random shuffle of numbers within a range.
      */
-    public function shuffle(int $minimumNumber = NULL, int $maximumNumber = NULL): array;
+    public function shuffle(int $minimumNumber = null, int $maximumNumber = null): array;
 
+    /**
+     * Reset the provable instance in order to start the results over from the top.
+     *
+     * @return \Gamebetr\Provable\ProvableInterface
+     *   An instance of this object.
+     */
+    public function reset(): self;
 }

--- a/tests/ProvableTest.php
+++ b/tests/ProvableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Gamebetr\Provable\Tests;
@@ -8,16 +9,17 @@ use Gamebetr\Provable\Provable;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class ProvableTest
+ * Class ProvableTest.
  *
  * @coversDefaultClass \Gamebetr\Provable\Provable
  */
-class ProvableTest extends TestCase {
-
+class ProvableTest extends TestCase
+{
     /**
      * @covers ::getClientSeed
      */
-    public function testGetClientSeed(): void {
+    public function testGetClientSeed(): void
+    {
         $this->assertEquals('abc123', (new Provable('abc123'))->getClientSeed());
     }
 
@@ -26,44 +28,50 @@ class ProvableTest extends TestCase {
      *
      * @depends testGetServerSeed
      */
-    public function testGetHashedServerSeed(): void {
+    public function testGetHashedServerSeed(): void
+    {
         $this->assertEquals('8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587', (new Provable('abc123', 'def456'))->getHashedServerSeed());
     }
 
     /**
      * @covers ::getMax
      */
-    public function testGetMax(): void {
-        $this->assertEquals(20, (new Provable('abc123', NULL, 0, 20))->getMax());
+    public function testGetMax(): void
+    {
+        $this->assertEquals(20, (new Provable('abc123', null, 0, 20))->getMax());
     }
 
     /**
      * @covers ::getMin
      */
-    public function testGetMin(): void {
-        $this->assertEquals(5, (new Provable('abc123', NULL, 5, 20))->getMin());
+    public function testGetMin(): void
+    {
+        $this->assertEquals(5, (new Provable('abc123', null, 5, 20))->getMin());
     }
 
     /**
      * @covers ::getServerSeed
      */
-    public function testGetServerSeed(): void {
+    public function testGetServerSeed(): void
+    {
         $this->assertEquals('def456', (new Provable('abc123', 'def456'))->getServerSeed());
     }
 
     /**
      * @covers ::getType
      */
-    public function testGetType(): void {
-        $this->assertEquals('number', (new Provable('abc123', NULL, 0, 10, 'number'))->getType());
-        $this->assertEquals('shuffle', (new Provable('abc123', NULL, 0, 10, 'shuffle'))->getType());
+    public function testGetType(): void
+    {
+        $this->assertEquals('number', (new Provable('abc123', null, 0, 10, 'number'))->getType());
+        $this->assertEquals('shuffle', (new Provable('abc123', null, 0, 10, 'shuffle'))->getType());
     }
 
     /**
      * @covers ::number
      * @covers ::generateSeedInteger
      */
-    public function testNumber(): void {
+    public function testNumber(): void
+    {
         $expected = [6, 9, 2, 8, 2];
         $provable = new Provable('abc123', 'def456', 0, 10, 'number');
         foreach ($expected as $expected_number) {
@@ -77,11 +85,12 @@ class ProvableTest extends TestCase {
      * @depends testNumber
      * @depends testShuffle
      */
-    public function testResults(): void {
-        $provable = new Provable('abc123', NULL, 0, 10, 'number');
+    public function testResults(): void
+    {
+        $provable = new Provable('abc123', null, 0, 10, 'number');
         $this->assertIsInt($provable->results());
 
-        $provable = new Provable('abc123', NULL, 0, 10, 'shuffle');
+        $provable = new Provable('abc123', null, 0, 10, 'shuffle');
         $this->assertIsArray($provable->results());
     }
 
@@ -89,7 +98,8 @@ class ProvableTest extends TestCase {
      * @covers ::setClientSeed
      * @covers ::generateRandomSeed
      */
-    public function testSetClientSeed(): void {
+    public function testSetClientSeed(): void
+    {
         $provable = new Provable('abc123');
         $this->assertEquals('abc123', $provable->getClientSeed());
         $provable->setClientSeed('def456');
@@ -103,8 +113,9 @@ class ProvableTest extends TestCase {
     /**
      * @covers ::setMax
      */
-    public function testSetMax(): void {
-        $provable = new Provable('abc123', NULL, 0, 10);
+    public function testSetMax(): void
+    {
+        $provable = new Provable('abc123', null, 0, 10);
         $this->assertEquals(10, $provable->getMax());
         $provable->setMax(5);
         $this->assertEquals(5, $provable->getMax());
@@ -113,8 +124,9 @@ class ProvableTest extends TestCase {
     /**
      * @covers ::setMin
      */
-    public function testSetMin(): void {
-        $provable = new Provable('abc123', NULL, 0);
+    public function testSetMin(): void
+    {
+        $provable = new Provable('abc123', null, 0);
         $this->assertEquals(0, $provable->getMin());
         $provable->setMin(5);
         $this->assertEquals(5, $provable->getMin());
@@ -124,7 +136,8 @@ class ProvableTest extends TestCase {
      * @covers ::setServerSeed
      * @covers ::generateRandomSeed
      */
-    public function testSetServerSeed(): void {
+    public function testSetServerSeed(): void
+    {
         $provable = new Provable('abc123');
         $this->assertNotNull($provable->getServerSeed());
         $provable->setServerSeed('def456');
@@ -134,9 +147,9 @@ class ProvableTest extends TestCase {
     /**
      * @covers ::setType
      */
-    public function testSetType(): void {
-
-        $provable = new Provable('abc123', NULL, 0, 10, 'number');
+    public function testSetType(): void
+    {
+        $provable = new Provable('abc123', null, 0, 10, 'number');
         $this->assertEquals('number', $provable->getType());
         $provable->setType('shuffle');
         $this->assertEquals('shuffle', $provable->getType());
@@ -146,7 +159,8 @@ class ProvableTest extends TestCase {
      * @covers ::shuffle
      * @covers ::generateSeedInteger
      */
-    public function testShuffle(): void {
+    public function testShuffle(): void
+    {
         $expected = [1, 3, 4, 0, 2, 5];
         $provable = new Provable('abc123', 'def456', 0, 5, 'shuffle');
         $this->assertEquals($expected, $provable->shuffle());
@@ -155,7 +169,8 @@ class ProvableTest extends TestCase {
     /**
      * @covers ::__construct
      */
-    public function test__construct(): void {
+    public function test__construct(): void
+    {
         $provable = new Provable('abc123', 'def456', 1, 10, 'number');
         $this->assertEquals('abc123', $provable->getClientSeed());
         $this->assertEquals('def456', $provable->getServerSeed());
@@ -171,7 +186,8 @@ class ProvableTest extends TestCase {
      * @depends testGetHashedServerSeed
      * @depends testGetServerSeed
      */
-    public function test_empty_server_seed_is_random(): void {
+    public function test_empty_server_seed_is_random(): void
+    {
         $provable_1 = new Provable('abc123');
         $provable_2 = new Provable('abc123');
 
@@ -184,9 +200,10 @@ class ProvableTest extends TestCase {
      *
      * @depends testSetType
      */
-    public function test_invalid_type_throws_exception(): void {
+    public function test_invalid_type_throws_exception(): void
+    {
         $this->expectException(Exception::class);
-        new Provable('abc123', NULL, 0, 10, 'RandomClass' . time());
+        new Provable('abc123', null, 0, 10, 'RandomClass'.time());
     }
 
     /**
@@ -194,7 +211,8 @@ class ProvableTest extends TestCase {
      *
      * @depends testNumber
      */
-    public function test_number_generation_is_repeatable(): void {
+    public function test_number_generation_is_repeatable(): void
+    {
         $rolls = [];
 
         $provable = new Provable('abc123', 'def456', 0, 10, 'number');
@@ -215,11 +233,53 @@ class ProvableTest extends TestCase {
     /**
      * @covers ::shuffle
      */
-    public function test_shuffle_range_is_min_max(): void {
+    public function test_shuffle_range_is_min_max(): void
+    {
         $provable = new Provable('abc123', 'def456', 1, 5, 'shuffle');
         $this->assertCount(5, $provable->shuffle());
 
         $this->assertCount(10, $provable->shuffle(1, 10));
     }
 
+    /**
+     * @covers ::number
+     * @covers ::shuffle
+     * @covers ::results
+     */
+    public function test_provable_is_resettable(): void
+    {
+        $rolls = [];
+        $provable = new Provable('abc123', 'def456', 1, 10, 'number');
+        for ($i = 0; $i < 10; $i++) {
+            $rolls[0][] = $provable->number();
+        }
+        sleep(3);
+        $provable->reset();
+        for ($i = 0; $i < 10; $i++) {
+            $rolls[1][] = $provable->number();
+        }
+        $this->assertEquals($rolls[0], $rolls[1]);
+        $rolls = [];
+        $provable = new Provable('abc123', 'def456', 1, 10, 'shuffle');
+        for ($i = 0; $i < 10; $i++) {
+            $rolls[0][] = $provable->shuffle();
+        }
+        sleep(3);
+        $provable->reset();
+        for ($i = 0; $i < 10; $i++) {
+            $rolls[1][] = $provable->shuffle();
+        }
+        $this->assertEquals($rolls[0], $rolls[1]);
+        $rolls = [];
+        $provable = new Provable('abc123', 'def456', 1, 10, 'number');
+        for ($i = 0; $i < 10; $i++) {
+            $rolls[0][] = $provable->results();
+        }
+        sleep(3);
+        $provable->reset();
+        for ($i = 0; $i < 10; $i++) {
+            $rolls[1][] = $provable->results();
+        }
+        $this->assertEquals($rolls[0], $rolls[1]);
+    }
 }


### PR DESCRIPTION
Added a reset() method to the Provable class and Provable interface. The reset method will reset the provable instance to the original state and results can start over from the top. 